### PR TITLE
doc: fix post-quantum option name, document `system [postquantum]`

### DIFF
--- a/documentation/sphinx/source/commands.rst
+++ b/documentation/sphinx/source/commands.rst
@@ -65,9 +65,22 @@ Commands
    showStrengthenedHyp    Show hypothesis after strengthening          false
    autoFADup              Automatic FA Dup                             true
    newInduction           New equivalence induction principle (FIXME)  false
-   postQuantumSound       Post-quantum soundness                       false
+   postQuantumEquivs      Post-quantum soundness                       false
    checkInclude           Include will check proofs                    true
    ====================== ============================================ ======================
+
+   .. note::
+
+      Post-quantum soundness has two parts. The ``postQuantumEquivs`` option
+      above enables the extra checks; in addition, systems to be analysed
+      against a quantum attacker are declared with the ``[postquantum]``
+      annotation::
+
+        system [postquantum] mysystem = (A: P | B: Q).
+
+      Both are needed together. The case studies in ``examples/pq-ccs-2026/``
+      open with ``close Classic.  open Quantum.  set postQuantumEquivs =
+      true.`` and declare every system ``[postquantum]``.
 
 .. cmd:: print {? @ident}
 

--- a/documentation/sphinx/source/doc-writing.rst
+++ b/documentation/sphinx/source/doc-writing.rst
@@ -389,7 +389,7 @@ Here is the list of all objects of the Squirrel domain (The symbol |black_nib| i
 
       .. code-block:: rst
 
-       .. flag:: postQuantumSound
+       .. flag:: postQuantumEquivs
 
           Perform extra checks to ensure that results
           are sound wrt a quantum adversary.
@@ -876,7 +876,7 @@ In addition to the objects and directives above, the ``squirrelrst`` Sphinx plug
 
              Apply tactics :g:`apply not_true; reflexivity` 
              or set options 
-             :g:`set postQuantumSound=true.`
+             :g:`set postQuantumEquivs=true.`
              or declare 
              :g:`(forall (a:'a), true) = true.`
 
@@ -884,7 +884,7 @@ In addition to the objects and directives above, the ``squirrelrst`` Sphinx plug
 
              Apply tactics :g:`apply not_true; reflexivity` 
              or set options 
-             :g:`set postQuantumSound=true.`
+             :g:`set postQuantumEquivs=true.`
              or declare 
              :g:`(forall (a:'a), true) = true.`
 


### PR DESCRIPTION
Two small documentation fixes, found while trying to put a development into the post-quantum model from the manual alone.

### 1. The documented option name is rejected

The manual gives the flag as `postQuantumSound`. The implementation registers `postQuantumEquivs` (`src/core/tConfig.ml:102`), and `postQuantumSound` appears nowhere in `src/`:

```
$ echo 'set postQuantumSound = true.' > t.sp && squirrel t.sp
Fatal error: exception Squirrelcore.Symbols.Error(_)
```

Fixed in all four occurrences:

| file | context |
|---|---|
| `commands.rst:68` | the options table |
| `doc-writing.rst:392` | the `.. flag::` example |
| `doc-writing.rst:879,887` | two `set ...=true.` snippets in the exception guidance |

### 2. `system [postquantum]` is not documented

`system [postquantum] ...` is implemented (`processDecl.ml` → `Action.PostQuantum`) and **all 16** files under `examples/pq-ccs-2026/` use it — all 16 also open with `close Classic.  open Quantum.  set postQuantumEquivs = true.` — but the annotation is not mentioned in the manual. Reading only the docs, the option alone looks sufficient for a post-quantum analysis.

The patch adds a short note to the options table recording that both parts are needed and pointing at the case studies. It deliberately only *mentions* the three-line idiom rather than specifying it, since I don't know whether `close Classic` is required for soundness or is convention — happy to expand it if you tell me which.

### Checked

Built with `make html` following `documentation/sphinx/README.rst` (sphinx 9.1.0, Python 3.13, the squirrel-prover pygments fork): builds clean, the only warning being the pre-existing `get_html_theme_path` deprecation. The note is indented into the `.. cmd:: set` body so the options table is not split.