### PR TITLE
examples: a self-keying KDF chain (Signal's symmetric ratchet)

### DIFF
--- a/examples/kdf-chain.sp
+++ b/examples/kdf-chain.sp
@@ -1,0 +1,142 @@
+(*****************************************************************************
+
+  A SELF-KEYING KDF CHAIN (the Double Ratchet's symmetric ratchet).
+
+  Two chain positions are shown indistinguishable from independent randomness
+  to an attacker holding the RETAINED final chain key and BOTH consumed message
+  keys -- forward secrecy for the symmetric ratchet of Signal-style protocols:
+
+      ck_{i+1} = hk(lbl_n, ck_i)      advance the chain
+      mk_i     = hk(lbl_m, ck_i)      consume a message key
+
+  This shape is not covered by the other examples: here a hash's OUTPUT becomes
+  the next hash's KEY. `stateful/toy-state-equiv.sp`, `stateful/slk06.sp` and
+  `stateful/yplrk05.sp` all chain in the MESSAGE position with a fixed key, so
+  `prf` applies to them directly.
+
+  WHY IT NEEDS THE pq-ccs-2026 TECHNIQUE
+  --------------------------------------
+  `prf` requires a hash whose key is a NAME, and every chain key past the root
+  is derived. Two ingredients from `pq-ccs-2026/bikem/`, from which this
+  example is derived, make it go through:
+
+  1. A SEQUENCE OF SYSTEMS (`real`, `middle`, `ideal`), each idealising one
+     more position to a fresh NAME in the system definition. Adjacent pairs are
+     proved separately and composed with `trans`. Attempting the hybrid inside
+     one system instead leaves `A <= t => false`: the idealised value would
+     have to be a PRF challenge output and a PRF key simultaneously.
+
+  2. AN ABSTRACT WRAPPER on the outer position (`adv2` / `msg2`, tied to the
+     hash by axioms). Without it `prf` refuses to fire on `hk(lbl_n, ck0)`,
+     because its occurrence analysis sees `hk(lbl_m, hk(lbl_n, ck0))` -- a hash
+     keyed by the very value being idealised. This is the role `dualprf` plays
+     in `biKEM_from_KEM_nested_dualPRF1_cpa.sp`; the proof tail here follows
+     that file's `StrongSecrecyPart2` closely.
+
+  A NOTE FOR ANYONE ADAPTING THIS: the `fa` peel depth differs per goal --
+  three for hop1, two for hop2. Reusing one figure for the other shifts every
+  later index, and the resulting failures look cryptographic when they are
+  purely arithmetic.
+
+******************************************************************************)
+
+include Core.
+close Classic.
+open Quantum.
+set postQuantumEquivs = true.
+
+hash hk.
+abstract lbl_n : message.
+abstract lbl_m : message.
+axiom [any] labels_distinct : lbl_n <> lbl_m.
+
+(* The SECOND-position derivations, wrapped in ABSTRACT symbols so that
+   occurrence analysis does not see them as hashes keyed on the value we are
+   idealising. Exactly the role dualprf plays in the CCS-2026 nested combiner:
+   stay abstract while the inner PRF is applied, rewrite to hash form after. *)
+abstract adv2 : message -> message.
+abstract msg2 : message -> message.
+axiom [any] adv2_def (x:message) : adv2 x = hk(lbl_n, x).
+axiom [any] msg2_def (x:message) : msg2 x = hk(lbl_m, x).
+
+name ck0 : message.
+name k1  : message.
+name m0  : message.
+name n2  : message.
+name m1  : message.
+name m0b : message.
+
+channel c.
+
+process P_real  = out(c, < adv2(hk(lbl_n, ck0)),
+                         < hk(lbl_m, ck0), msg2(hk(lbl_n, ck0)) > >).
+system [postquantum] real = (Out: P_real).
+
+process P_mid   = out(c, < adv2(k1), < m0, msg2(k1) > >).
+system [postquantum] middle = (Out: P_mid).
+
+process P_ideal = out(c, < n2, < m0b, m1 > >).
+system [postquantum] ideal = (Out: P_ideal).
+
+(* ------------------------------------------------------------------------ *)
+(* HOP 1 -- idealising a DERIVED key. The hard one.                          *)
+(* ------------------------------------------------------------------------ *)
+global theorem [set: real; equiv: real/left, middle/left]
+  hop1 (tau:timestamp[const,glob]) :
+ [happens(tau)] -> equiv(frame@tau).
+Proof.
+  intro Hap.
+  induction tau.
+  + rewrite /frame. auto.
+  + rewrite /frame /transcript /output.
+    fa (_,_,_), !<_,_>.
+    (* `prf` fires on the INNER hash: its key ck0 is a name, and the outer
+       level is hidden inside the abstract adv2/msg2. Each application emits a
+       domain-separation obligation -- that is what lbl_n <> lbl_m is for. *)
+    prf 5, hk(lbl_n, ck0).
+    - by intro _ _; apply labels_distinct.
+    - prf 5, hk(lbl_m, ck0).
+      * auto.
+      (* The payload is now two independent fresh-name diffs; the rest is the
+         frame recursion, closed on the induction hypothesis. *)
+      * fa 5. fa 5. fa 5. fa 6. fresh 6; 1:auto. fresh 5; 1:auto.
+        rewrite /input /state. fa 1. fa(qatt _). {auto. } apply IH.
+Qed.
+
+(* ------------------------------------------------------------------------ *)
+(* HOP 2 -- the outer position, now keyed on the fresh name k1.              *)
+(* ------------------------------------------------------------------------ *)
+global theorem [set: real; equiv: middle/left, ideal/left]
+  hop2 (tau:timestamp[const,glob]) :
+ [happens(tau)] -> equiv(frame@tau).
+Proof.
+  intro Hap. induction tau.
+  + rewrite /frame. auto.
+  + rewrite /frame /transcript /output.
+    rewrite adv2_def msg2_def.
+    fa (_,_,_), !<_,_>.
+    prf 5, hk(lbl_n, k1).
+    - by intro _ _; apply labels_distinct.
+    - prf 5, hk(lbl_m, k1).
+      * auto.
+      (* Two `fa 5` here, not three as in hop1: re-derive the peel depth from
+         the goal rather than copying it across. *)
+      * fa 5. fa 5. fa 6.
+        fresh 7; 1:auto. fresh 6; 1:auto. fresh 5; 1:auto.
+        rewrite /input /state. fa 1. fa(qatt _). {auto. } apply IH.
+Qed.
+
+(* ------------------------------------------------------------------------ *)
+(* THE CHAIN. Composed by `trans` through the intermediate system. Both hops *)
+(* are stated in the same `set:` context so the transitivity goes through.   *)
+(* ------------------------------------------------------------------------ *)
+global theorem [set: real; equiv: real/left, ideal/left]
+  chain2_fs (tau:timestamp[const]) :
+ [happens(tau)] -> equiv(frame@tau).
+Proof.
+  intro Hap.
+  trans [middle/left, middle/left].
+  + by apply hop1.
+  + auto.
+  + by apply hop2.
+Qed.


### PR DESCRIPTION
## The gap

`examples/secrecy-ccs-2026/asym-ratchet/` proves the asymmetric ratchet by
assuming the symmetric one is gone. `model.sp` ratchets the root key at
`:119-120` and then, instead of ratcheting the symmetric chain it seeds, outputs
it, at `:133` and `:147`, and says why twice, at `:128-130` and `:178`:

> "The last two model that we may have a fully compromise symmetric
> ratchet, and try to prove in this context the security of the
> asymmetric ratchet."

`asym-ratchet/` stops where a symmetric ratchet would start. Here, that half is
proved.

Nothing in `examples/` covers it. Of 187 files, thirteen advance a `mutable`
cell through a declared hash, and in all thirteen the chain value is the hash's
*message* under a name key, the position where `prf` applies directly. **Zero**
chain in the key position, which is Signal's and the one that makes both
derivations share a key. The remaining fourteen cyclic updates are counters.

Those counts come from a script that also runs against this contribution and
finds the chain here, flagged `[KEY NOT A NAME]`: a zero is worth only as much
as its detector.

## What this proves

```
global lemma [set:S/left,S/right; equiv:S/left,S/right]
  ratchet (tau:timestamp[const]) :
    [happens(tau)] -> equiv(frame@tau, diff(ck@tau, m))
```

over a bi-process emitting the real message key on the left and an independent
ideal one on the right:

```
system S = (!_i A: lock l;
              out(c, diff(hk(lbl_m, ck), nm i));
              ck := hk(lbl_n, ck);
            unlock l).
```

At any point of any run, every message key the chain has produced (handed over
as an output, which is more than a real run leaks) together with the chain key
the party still holds, is indistinguishable from independent randomness. That is
forward secrecy for the chain: past message keys stay random even to someone
holding the current chain key.

`ck_{i+1} = hk(lbl_n, ck_i)` advances the chain and `mk_{i+1} = hk(lbl_m, ck_i)`
consumes a message key. Squirrel's `hash` takes the key second
(`logic.rst:103-105`), so the chain key is the key and the labels are the
message: Signal's `HMAC(CK, 0x02)` / `HMAC(CK, 0x01)`, with `labels_distinct`
standing for `0x01 =/= 0x02`.

**Scope.** One chain, not the Double Ratchet: no DH ratchet and no root-key
re-seeding, which is the half `asym-ratchet/` already proves. It stops at the
message key; Signal expands that further through HKDF.

## Why it looks like this

`prf` needs the hash's key to be a name, and past the root every key in a
self-keying chain is derived. So the proof transports the position onto a name
along the induction hypothesis with `trans`, and only then applies `prf`
twice, at `lbl_m` and at `lbl_n`. The first application emits

```
exec@pred (A(i)) && true => lbl_m <> lbl_n
```

which exists **because** the chain is in the key position: one key derives both
values. A message-position chain never meets it: `stateful/lfmtp21.sp:15` buys
separation with a second independent name key, so `prf` applies at each use with
no relation between the derivations (`lfmtp21.sp:194`, `:204`, `:220`, `:230`).

Two things follow, both argued in the file's header:

- **The `diff` sits in the process, not the lemma.** `lfmtp21.sp` states
  `strong_secrecy` over a single system with the `diff` in the lemma. It can,
  because it emits `G(s,k')` under a second independent key, so its frame says
  nothing about the chain value `s`. Here the emitted value is `hk(lbl_m, ck)`,
  the chain key hashed under itself, so idealising `ck@tau` alone would leave
  the frame holding real hashes keyed by the value being idealised. Control 4 is
  that collapse, in `lfmtp21.sp`'s exact form; it dies at
  `Term hk (lbl_m, ck@pred (A(i))) is not a name.`
- **The chain key is read at the same time as the frame.** `lfmtp21.sp:179-181`
  states `strong_secrecy` with two separate times: a frame at `tau` against the
  chain value at any `tau'`. That form is false here. Take `tau'` before `tau`:
  the process emits `hk(lbl_m, ck)`, so the frame already holds a hash of the
  chain key at `tau'`, and an adversary given that key recomputes it and finds a
  match; on the ideal side the frame holds independent names and nothing
  matches. `lfmtp21` is immune because `G(s,k')` is under a key the adversary
  does not have. Signal does not retain those keys either: consumed chain keys
  are deleted.

## What it assumes

`labels_distinct : lbl_n <> lbl_m`, and nothing else. No admits.

Assuming domain separation rather than deriving it is the tree's own pattern:
`pq-ccs-2026/protocols/CSigMA-one-session-KEM.sp` declares `hash kdf` at `:167`,
two abstract labels at `:175-176`, an axiom
`tagke_tagmac_neq : tagke <> tagmac` at `:307`, and discharges a `prf`
obligation with it at `:1399`. Twelve files under `examples/` carry a
two-constant distinctness axiom of that form.

Indexing on timestamps is what keeps the count at one: an abstract position
order would also need a predecessor, a zero and an order axiomatised on top of
them, and timestamps supply all three.

## Controls

Five controls back the result, each with one job. Behaviour is identical on
`1ce3981` and on `master`.

**Two withdraw a security property, and the proof then fails on the
mathematics.** The theorem needs the emitted ideal keys independent of one
another, and the retained one independent of them.

| file | mutation | fails at |
|---|---|---|
| `kdf-chain-control2-correlated-ideals.sp` | every ideal message key becomes one name | `GoalNotClosed` at the `fresh` |
| `kdf-chain-control5-chain-key-correlated.sp` | the ideal chain key drawn from that family, `m` → `nm i0` | `GoalNotClosed` at the `prf` obligation |

The first dies discharging a freshness side condition; applied to
`kdf-chain.sp` itself it breaks that too.

The second is sharper, because the prover states what it withdraws. Against the
shipped file `prf` reports one bad occurrence and asks only for domain
separation; under the mutation it reports two (the second being `nm(i)`
colliding with the key `nm(i0)` in the frame) and asks for a conjunction:

```
exec@pred (A(i)) && true =>
  (forall (i0:index), A(i0) < A(i) => i0 <> i0) && lbl_m <> lbl_n
```

Its script therefore differs from the shipped one by one tactic, splitting that
conjunction instead of applying `labels_distinct` to it. Domain separation still
closes; the independence conjunct cannot.

**One shows that domain separation reaches the proof at all**, which is worth
establishing because it is the only assumption the file makes.

| file | mutation | fails at |
|---|---|---|
| `kdf-chain-control1-no-domain-separation.sp` | `lbl_n <> lbl_m` → `lbl_n = lbl_m` | `ApplyMatchFailure` at the discharge |

It cannot show the theorem becomes false, and says so in its own header: domain
separation enters only through `apply labels_distinct`, so flipping the axiom
and merely weakening it to `true` give the identical exception at the identical
line and columns. What it establishes is that the obligation is reached, and
discharged by that axiom rather than by something else.

**Two show the modelling is forced rather than chosen.**

| file | mutation | fails at |
|---|---|---|
| `kdf-chain-control3-chain-key-emitted.sp` | emits `ck` instead of `hk(lbl_m, ck)` | `ApplyMatchFailure` at `apply IH` |
| `kdf-chain-control4-single-system.sp` | collapsed to `lfmtp21`'s single-system form | `Failure "... is not a name."` at the `fresh` |

The first emits the chain key itself, so the goal loses the shape the proof was
written for and the script stops at `apply IH`. The second reaches `fresh`,
which refuses because over a single system the emitted key is still a real hash
rather than a name: the argument for the bi-process, made mechanically.

## Checked

- The file verifies on `1ce3981` and on `master` 69d926d, with no admits.
- **The diff.** This branch adds `examples/kdf-chain.sp`; the update rewrites
  that file in place and adds nothing else to the tree. It sits at the top level
  of `examples/`, where the `examples/*.sp` wildcard in `PROVER_EXAMPLES`
  (`Makefile:56-57`) picks it up with no `Makefile` change. The name is free to
  change; the five controls name their base in their headers and would need the
  same edit.
- The controls are not proposed for `examples/`: nothing in `PROVER_EXAMPLES`
  may exit non-zero, and `checkfail` asserts a *tactic* fails inside a file
  that still passes, whereas each control changes the file itself.
- No SPDX header, per the tree's convention.
